### PR TITLE
Prettier test output + test logic clean up

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,20 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:c16f511247fb7dd5b3e8428bed24b9f74473f343b3fb7c14763b47f567feb8a5"
-  name = "github.com/bclicn/color"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "108f2023dc84f1f9e64f246fa3997993971b2706"
-
-[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:be40f095cd741773905744f16c1f7a21fd9226ccd0529f019deb7da6d667f71c"
+  name = "github.com/logrusorgru/aurora"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a7b3b318ed4e1ae5b80602b08627267303c68572"
 
 [[projects]]
   digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
@@ -64,7 +64,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/bclicn/color",
+    "github.com/logrusorgru/aurora",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,22 @@
   revision = "a7b3b318ed4e1ae5b80602b08627267303c68572"
 
 [[projects]]
+  digest = "1:cdb899c199f907ac9fb50495ec71212c95cb5b0e0a8ee0800da0238036091033"
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb"
+  version = "v0.0.3"
+
+[[projects]]
+  digest = "1:abcdbf03ca6ca13d3697e2186edc1f33863bbdac2b3a44dfa39015e8903f7409"
+  name = "github.com/olekukonko/tablewriter"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e6d60cf7ba1f42d86d54cdf5508611c4aafb3970"
+  version = "v0.0.1"
+
+[[projects]]
   digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -65,6 +81,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/logrusorgru/aurora",
+    "github.com/olekukonko/tablewriter",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
   ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,13 +72,14 @@ var RootCmd = &cobra.Command{
 
 		// Test setup
 		tests, err := getTestsToRun(args)
+		if err != nil {
+			logrus.Fatalf("Error getting tests to run: %v", err)
+		}
 		// Run the tests
 		for loopIndex := 0; loopIndex < loops || loops == 0; loopIndex++ {
 			logrus.Infof("Test loop nr: %d, numRuns: %d", loopIndex+1, numRuns)
 			for _, test := range tests {
-				if skipRebuildTest {
-					test.SkipRebuild = true
-				}
+				test.SkipRebuild = skipRebuildTest
 				if err = testProcedure(test, env, mother); err != nil {
 					logrus.Warningf("error running test %s: %v", test.Name, err)
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,14 +76,22 @@ var RootCmd = &cobra.Command{
 			logrus.Fatalf("Error getting tests to run: %v", err)
 		}
 		// Run the tests
+		var testFailed bool
 		for loopIndex := 0; loopIndex < loops || loops == 0; loopIndex++ {
 			logrus.Infof("Test loop nr: %d, numRuns: %d", loopIndex+1, numRuns)
 			for _, test := range tests {
 				test.SkipRebuild = skipRebuildTest
-				if err = testProcedure(test, env, mother); err != nil {
+				passed, err := testProcedure(test, env, mother)
+				if err != nil {
 					logrus.Warningf("error running test %s: %v", test.Name, err)
 				}
+				if !passed {
+					testFailed = true
+				}
 			}
+		}
+		if testFailed {
+			logrus.Fatalf("More than 1 test has failed")
 		}
 	},
 }

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -14,6 +14,7 @@ import (
 func testProcedure(test *testFramework.TestConfig, env environment.Environment, mother *mothership.Mothership) error {
 	pretty := pretty.NewPrettyTest(test.Name)
 	pretty.PrintHeader()
+	pretty.Print(test)
 
 	// BUILD & DEPLOY. 3 options:
 	// 1. Push NaCl and build on Mothership

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -14,7 +14,7 @@ import (
 func testProcedure(test *testFramework.TestConfig, env environment.Environment, mother *mothership.Mothership) error {
 	pretty := pretty.NewPrettyTest(test.Name)
 	pretty.PrintHeader()
-	pretty.Print(test)
+	pretty.PrintTable(test.StringSlice())
 
 	// BUILD & DEPLOY. 3 options:
 	// 1. Push NaCl and build on Mothership
@@ -35,12 +35,7 @@ func testProcedure(test *testFramework.TestConfig, env environment.Environment, 
 	}
 
 	// RESULTS print test results
-	if result.SuccessPercentage > 50 {
-		pretty.PrintResult(true)
-	} else {
-		pretty.PrintResult(false)
-	}
-	logrus.Info(result)
+	pretty.PrintTable(result.StringSlice())
 
 	// VERIFY starbase status
 	health := mother.CheckInstanceHealth()

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func testProcedure(test *testFramework.TestConfig, env environment.Environment, mother *mothership.Mothership) error {
+func testProcedure(test *testFramework.TestConfig, env environment.Environment, mother *mothership.Mothership) (bool, error) {
 	pretty := pretty.NewPrettyTest(test.Name)
 	pretty.PrintHeader()
 	pretty.PrintTable(test.StringSlice())
@@ -21,7 +21,7 @@ func testProcedure(test *testFramework.TestConfig, env environment.Environment, 
 	// 2. Build service locally using docker
 	// 3. No building at all
 	if err := build(test, mother); err != nil {
-		return fmt.Errorf("error building: %v", err)
+		return false, fmt.Errorf("error building: %v", err)
 	}
 
 	// TEST script. 2 options:
@@ -31,7 +31,7 @@ func testProcedure(test *testFramework.TestConfig, env environment.Environment, 
 	// numRuns flag taken into account
 	result, err := test.RunTest(numRuns, env, mother)
 	if err != nil {
-		return fmt.Errorf("error running test %v", err)
+		return false, fmt.Errorf("error running test %v", err)
 	}
 
 	// RESULTS print test results
@@ -42,7 +42,7 @@ func testProcedure(test *testFramework.TestConfig, env environment.Environment, 
 	logrus.Info(health)
 
 	pretty.EndTest()
-	return nil
+	return result.Result, nil
 }
 
 func getTestsToRun(possibleTests []string) ([]*testFramework.TestConfig, error) {

--- a/prettyoutput/pretty.go
+++ b/prettyoutput/pretty.go
@@ -2,9 +2,10 @@ package pretty
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
-	"github.com/logrusorgru/aurora"
+	"github.com/olekukonko/tablewriter"
 )
 
 const width = 80
@@ -12,29 +13,29 @@ const width = 80
 var separator = strings.Repeat("=", width)
 
 type PrettyTest struct {
-	Name string
+	Name  string
+	table *tablewriter.Table
 }
 
 func NewPrettyTest(name string) PrettyTest {
-	return PrettyTest{Name: name}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAutoWrapText(false)
+	return PrettyTest{Name: name, table: table}
 }
 
 func (t PrettyTest) PrintHeader() {
-	fmt.Println(separator)
+	title := fmt.Sprintf(" test: %s ", t.Name)
+	lenTitle := len(title)
+	fillEachSide := (width - lenTitle) / 2
+	fill := strings.Repeat("=", fillEachSide)
+	fmt.Printf("%s%s%s\n", fill, title, fill)
 }
 
-func (t PrettyTest) Print(x interface{}) {
-	fmt.Println(x)
-}
-
-func (t PrettyTest) PrintResult(result bool) {
-	var output string
-	if result {
-		output = aurora.BgGreen(" PASS ").String()
-	} else {
-		output = aurora.BgRed(" FAIL ").String()
-	}
-	fmt.Printf("Test result: [ %s ]\n", output)
+func (t PrettyTest) PrintTable(data [][]string) {
+	t.table.ClearRows()
+	t.table.AppendBulk(data)
+	t.table.Render()
 }
 
 func (t PrettyTest) EndTest() {

--- a/prettyoutput/pretty.go
+++ b/prettyoutput/pretty.go
@@ -20,9 +20,11 @@ func NewPrettyTest(name string) PrettyTest {
 }
 
 func (t PrettyTest) PrintHeader() {
-	fmt.Printf("%s\n"+
-		"Test: %s\n"+
-		"Test-info: blah blah\n", separator, t.Name)
+	fmt.Println(separator)
+}
+
+func (t PrettyTest) Print(x interface{}) {
+	fmt.Println(x)
 }
 
 func (t PrettyTest) PrintResult(result bool) {

--- a/prettyoutput/pretty.go
+++ b/prettyoutput/pretty.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bclicn/color"
+	"github.com/logrusorgru/aurora"
 )
 
 const width = 80
@@ -28,9 +28,9 @@ func (t PrettyTest) PrintHeader() {
 func (t PrettyTest) PrintResult(result bool) {
 	var output string
 	if result {
-		output = color.BGreen("PASS")
+		output = aurora.BgGreen(" PASS ").String()
 	} else {
-		output = color.BRed("FAIL")
+		output = aurora.BgRed(" FAIL ").String()
 	}
 	fmt.Printf("Test result: [ %s ]\n", output)
 }

--- a/testFramework/saveRead.go
+++ b/testFramework/saveRead.go
@@ -66,7 +66,7 @@ func ReadFromDisk(testPath string) (*TestConfig, error) {
 
 // verifyTestFiles checks for the existence of selected files in the path supplied
 func verifyTestFiles(testPath string) error {
-	expectedFiles := []string{"testspec.json", "*.nacl", "*.sh"}
+	expectedFiles := []string{"testspec.json", "*.sh"}
 
 	for _, file := range expectedFiles {
 		pathToCheck := path.Join(testPath, file)

--- a/testFramework/tests.go
+++ b/testFramework/tests.go
@@ -25,7 +25,6 @@ type TestConfig struct {
 	HostCommandScript   string                 `json:"hostcommandscript"`
 	Setup               environment.SSHClients `json:"setup"`
 	Cleanup             environment.SSHClients `json:"cleanup"`
-	ShouldFail          bool                   `json:"shouldfail"`
 	CustomServicePath   string                 `json:"customservicepath"`
 	NoDeploy            bool                   `json:"nodeploy"`
 	SkipRebuild         bool
@@ -84,11 +83,6 @@ func (c TestConfig) StringSlice() [][]string {
 		output = append(output, []string{"Script type", "[ ] ClientCommandScript / [X] HostCommandScript"})
 	}
 	output = append(output, []string{"Custom service", c.CustomServicePath})
-	if c.ShouldFail {
-		output = append(output, []string{"Should fail", "[X]"})
-	} else {
-		output = append(output, []string{"Should fail", "[ ]"})
-	}
 	if c.NoDeploy {
 		output = append(output, []string{"No deploy", "[X]"})
 	} else {

--- a/testFramework/tests.go
+++ b/testFramework/tests.go
@@ -56,6 +56,38 @@ func (tr TestResult) String() string {
 	return fmt.Sprintf("Result: %.1f%% %d/%d, Name: %s, ShouldFail: %t", tr.SuccessPercentage, tr.Received, tr.Sent, tr.Name, tr.ShouldFail)
 }
 
+func (c TestConfig) String() string {
+	var output string
+	var width = 15
+	output = output + fmt.Sprintf("%-*s %s\n", width, "Name:", c.Name)
+
+	if c.ClientCommandScript != "" {
+		output = output + fmt.Sprintf("%-*s [X] ClientCommandScript / [ ] HostCommandScript\n"+
+			"%-*s Path: %s\n", width, "Script:", width, "", c.ClientCommandScript)
+	} else if c.HostCommandScript != "" {
+		output = output + fmt.Sprintf("%-*s [ ] ClientCommandScript / [X] HostCommandScript\n"+
+			"%-*s Path: %s\n", width, "Script:", width, "", c.HostCommandScript)
+	}
+	output = output + fmt.Sprintf("%-*s %s\n", width, "Custom service:", c.CustomServicePath)
+
+	if c.ShouldFail {
+		output = output + fmt.Sprintf("%-*s [X]\n", width, "Should fail:")
+	} else {
+		output = output + fmt.Sprintf("%-*s [ ]\n", width, "Should fail:")
+	}
+	if c.NoDeploy {
+		output = output + fmt.Sprintf("%-*s [X]\n", width, "No deploy:")
+	} else {
+		output = output + fmt.Sprintf("%-*s [ ]\n", width, "No deploy:")
+	}
+	if c.SkipRebuild {
+		output = output + fmt.Sprintf("%-*s [X]\n", width, "Skip rebuild:")
+	} else {
+		output = output + fmt.Sprintf("%-*s [ ]\n", width, "Skip rebuild:")
+	}
+	return output
+}
+
 // RunTest runs the clientCmdScript on either host or client1 level number of times and returns a TestResult
 func (t *TestConfig) RunTest(level int, env environment.Environment, mother *mothership.Mothership) (TestResult, error) {
 	// Prepare test before run

--- a/testFramework/tests.go
+++ b/testFramework/tests.go
@@ -8,8 +8,10 @@ import (
 	"html/template"
 	"io/ioutil"
 	"path"
+	"strconv"
 	"time"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/mnordsletten/lotto/environment"
 	"github.com/mnordsletten/lotto/mothership"
 	"github.com/mnordsletten/lotto/util"
@@ -33,16 +35,19 @@ type TestConfig struct {
 	NaclFileShasum      string
 }
 
+type testResponse struct {
+	Result   bool    `json:"result"`   // Pass/Fail of the test
+	Sent     int     `json:"sent"`     // Number of tests started
+	Received int     `json:"received"` // Number of responses received
+	Rate     float32 `json:"rate"`     // Requests pr second
+	Raw      string  `json:"raw"`      // Raw output from test
+}
+
 type TestResult struct {
-	Time              string  // Time that test results were recorded
-	Name              string  // Name of test
-	Sent              int     // Total number of requests sent
-	Received          int     // Total number of replies received
-	Rate              float32 // Requests pr second
-	Avg               float32 // Average response time
-	SuccessPercentage float32 // Percentage of packets that pass
-	Raw               string  // Raw output from the command
-	ShouldFail        bool    // If the test expects to fail
+	Name              string        // Name of test
+	Duration          time.Duration // Time to execute test
+	SuccessPercentage float32       // Percentage success
+	testResponse
 }
 
 type HostCommandTemplate struct {
@@ -52,54 +57,66 @@ type HostCommandTemplate struct {
 	BuilderID                string
 }
 
-func (tr TestResult) String() string {
-	return fmt.Sprintf("Result: %.1f%% %d/%d, Name: %s, ShouldFail: %t", tr.SuccessPercentage, tr.Received, tr.Sent, tr.Name, tr.ShouldFail)
+func (r TestResult) StringSlice() [][]string {
+	var result string
+	if r.Result {
+		result = fmt.Sprintf("[%s]", aurora.BgGreen(" PASS "))
+	} else {
+		result = fmt.Sprintf("[%s]", aurora.BgRed(" FAIL "))
+	}
+	return [][]string{
+		[]string{"Result", result},
+		[]string{"Sent", strconv.Itoa(r.Sent)},
+		[]string{"Received", strconv.Itoa(r.Received)},
+		[]string{"Percentage", fmt.Sprintf("%.1f%%", r.SuccessPercentage)},
+		[]string{"Rate", fmt.Sprintf("%.2f", r.Rate)},
+		[]string{"Duration", r.Duration.Truncate(1 * time.Second).String()},
+	}
 }
 
-func (c TestConfig) String() string {
-	var output string
-	var width = 15
-	output = output + fmt.Sprintf("%-*s %s\n", width, "Name:", c.Name)
-
+func (c TestConfig) StringSlice() [][]string {
+	var output [][]string
 	if c.ClientCommandScript != "" {
-		output = output + fmt.Sprintf("%-*s [X] ClientCommandScript / [ ] HostCommandScript\n"+
-			"%-*s Path: %s\n", width, "Script:", width, "", c.ClientCommandScript)
+		output = append(output, []string{"Path", c.ClientCommandScript})
+		output = append(output, []string{"Script type", "[X] ClientCommandScript / [ ] HostCommandScript"})
 	} else if c.HostCommandScript != "" {
-		output = output + fmt.Sprintf("%-*s [ ] ClientCommandScript / [X] HostCommandScript\n"+
-			"%-*s Path: %s\n", width, "Script:", width, "", c.HostCommandScript)
+		output = append(output, []string{"Path", c.HostCommandScript})
+		output = append(output, []string{"Script type", "[ ] ClientCommandScript / [X] HostCommandScript"})
 	}
-	output = output + fmt.Sprintf("%-*s %s\n", width, "Custom service:", c.CustomServicePath)
-
+	output = append(output, []string{"Custom service", c.CustomServicePath})
 	if c.ShouldFail {
-		output = output + fmt.Sprintf("%-*s [X]\n", width, "Should fail:")
+		output = append(output, []string{"Should fail", "[X]"})
 	} else {
-		output = output + fmt.Sprintf("%-*s [ ]\n", width, "Should fail:")
+		output = append(output, []string{"Should fail", "[ ]"})
 	}
 	if c.NoDeploy {
-		output = output + fmt.Sprintf("%-*s [X]\n", width, "No deploy:")
+		output = append(output, []string{"No deploy", "[X]"})
 	} else {
-		output = output + fmt.Sprintf("%-*s [ ]\n", width, "No deploy:")
+		output = append(output, []string{"No deploy", "[ ]"})
 	}
 	if c.SkipRebuild {
-		output = output + fmt.Sprintf("%-*s [X]\n", width, "Skip rebuild:")
+		output = append(output, []string{"Skip rebuild", "[X]"})
 	} else {
-		output = output + fmt.Sprintf("%-*s [ ]\n", width, "Skip rebuild:")
+		output = append(output, []string{"Skip rebuild", "[ ]"})
 	}
 	return output
 }
 
 // RunTest runs the clientCmdScript on either host or client1 level number of times and returns a TestResult
-func (t *TestConfig) RunTest(level int, env environment.Environment, mother *mothership.Mothership) (TestResult, error) {
+func (t *TestConfig) RunTest(iterations int, env environment.Environment, mother *mothership.Mothership) (TestResult, error) {
 	// Prepare test before run
+	logrus.Info("Preparing clients")
 	if err := t.runScriptsOnClients(env, t.Setup); err != nil {
 		return TestResult{}, fmt.Errorf("error preparing test: %v", err)
 	}
 	defer t.cleanupTest(mother, env)
 	var results []TestResult
-	for i := 0; i < level; i++ {
+	logrus.Info("Starting test")
+	for i := 0; i < iterations; i++ {
 		var testOutput []byte
 		var testResult TestResult
 		testResult.Name = t.Name
+		start := time.Now()
 		var err error
 		// Run test either in client or in host
 		if t.ClientCommandScript != "" {
@@ -113,24 +130,14 @@ func (t *TestConfig) RunTest(level int, env environment.Environment, mother *mot
 		} else {
 			return testResult, fmt.Errorf("no testFile found")
 		}
+		testResult.Duration = time.Now().Sub(start)
 
 		// Parse test results
 		if err = json.Unmarshal(testOutput, &testResult); err != nil {
 			return testResult, fmt.Errorf("could not parse testResults: %v", err)
 		}
-		testResult.Time = time.Now().Format(time.RFC3339)
 
 		// Calculate success
-		testResult.ShouldFail = t.ShouldFail
-		if t.ShouldFail {
-			if testResult.Received > 0 {
-				testResult.SuccessPercentage = 0
-			} else {
-				testResult.SuccessPercentage = 100
-			}
-		} else {
-			testResult.SuccessPercentage = float32(testResult.Received) / float32(testResult.Sent) * 100
-		}
 		results = append(results, testResult)
 	}
 	return combineTestResults(results), nil
@@ -216,22 +223,18 @@ func (t *TestConfig) cleanupTest(mother *mothership.Mothership, env environment.
 
 func combineTestResults(results []TestResult) TestResult {
 	end := TestResult{}
+	end.Result = true // true until otherwise proven
 	for _, result := range results {
+		if !result.Result {
+			end.Result = false
+		}
 		end.Name = result.Name
 		end.Sent += result.Sent
 		end.Received += result.Received
 		end.Rate += result.Rate
-		end.ShouldFail = result.ShouldFail
+		end.Duration += result.Duration
 	}
-	if end.ShouldFail {
-		if end.Received > 0 {
-			end.SuccessPercentage = 0
-		} else {
-			end.SuccessPercentage = 100
-		}
-	} else {
-		end.SuccessPercentage = float32(end.Received) / float32(end.Sent) * 100
-	}
-	end.Time = time.Now().Format(time.RFC3339)
+	end.Rate = end.Rate / float32(len(results))
+	end.SuccessPercentage = float32(end.Received) / float32(end.Sent) * 100
 	return end
 }

--- a/tests/acorn/hey-acorn.sh
+++ b/tests/acorn/hey-acorn.sh
@@ -5,11 +5,11 @@
 # Input values to cmd
 sent=1000
 concurrency=100
-cmdOut=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30)
+raw=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30)
 
 # Parse output, important to set a default value if the command over fails
-receivedStatus=$(printf "%s" "$cmdOut" | awk '/responses/ {print $1}' )
-received=$(printf "%s" "$cmdOut" | awk '/responses/ {print $2}' )
+receivedStatus=$(printf "%s" "$raw" | awk '/responses/ {print $1}' )
+received=$(printf "%s" "$raw" | awk '/responses/ {print $2}' )
 
 if [[ "$receivedStatus" != "[200]" ]]; then
     received=0;
@@ -17,18 +17,27 @@ elif [ -z $received ]; then
     received=0;
 fi
 
-rate=$(printf "%s" "$cmdOut" | awk '/Requests\/sec/ {print $2}' )
-if [ -z $rate ]; then rate=0; fi
-avg=$(printf "%s" "$cmdOut" | awk '/Average/ {print $2}' )
-if [ -z $avg ]; then avg=0; fi
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+rate=$(printf "%s" "$raw" | awk '/Requests\/sec/ {print $2}' )
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/alias-update/alias.sh
+++ b/tests/alias-update/alias.sh
@@ -1,6 +1,5 @@
 # alias update script
 # Script used for checking that changing the alias of the instance works
-set -e
 
 moth="{{.MothershipBinPathAndName}}"
 instAlias={{.OriginalAlias}}
@@ -23,7 +22,7 @@ do
 
     sent=$[$sent + 1]
     # Change alias
-    raw=$($moth instance-alias $ID $alias)
+    raw+=$($moth instance-alias $ID $alias 2>&1)
     # Verify that the alias was actually changed
     existingAlias=$($moth inspect-instance $ID -o json | jq -r '.alias')
     if [[ "$existingAlias" == "$alias" ]]; then
@@ -33,10 +32,12 @@ do
 done
 
 # Reset to original alias
-raw+=$($moth instance-alias $ID $instAlias)
+raw+=$($moth instance-alias $ID $instAlias 2>&1)
 
 # All commands above succeeded
-result=true
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
 
 if [ -z $result ]; then result=false; fi
 if [ -z $sent ]; then sent=0; fi

--- a/tests/arp-interface-high/nping-arp.sh
+++ b/tests/arp-interface-high/nping-arp.sh
@@ -4,21 +4,33 @@
 
 # Input values to cmd
 sent=500
+target=460
 rate=100 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
+raw=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep Rcvd | cut -d ' ' -f 8)
+# Parse output
+received=$(printf "%s" "$raw" | grep Rcvd | cut -d ' ' -f 8)
+
+# If we receive more than 450 then the test passes
+if [ "$received" -gt "$target" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/arp-interface-low/nping-arp.sh
+++ b/tests/arp-interface-low/nping-arp.sh
@@ -4,21 +4,33 @@
 
 # Input values to cmd
 sent=500
+target=490
 rate=10 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
+raw=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep Rcvd | cut -d ' ' -f 8)
+# Parse output
+received=$(printf "%s" "$raw" | grep Rcvd | cut -d ' ' -f 8)
+
+# If we receive more than 450 then the test passes
+if [ "$received" -gt "$target" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/arp-interface-medium/nping-arp.sh
+++ b/tests/arp-interface-medium/nping-arp.sh
@@ -4,21 +4,33 @@
 
 # Input values to cmd
 sent=500
+target=480
 rate=50 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
+raw=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep Rcvd | cut -d ' ' -f 8)
+# Parse output
+received=$(printf "%s" "$raw" | grep Rcvd | cut -d ' ' -f 8)
+
+# If we receive more than 450 then the test passes
+if [ "$received" -gt "$target" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/arp-interface-very-high/nping-arp.sh
+++ b/tests/arp-interface-very-high/nping-arp.sh
@@ -4,21 +4,33 @@
 
 # Input values to cmd
 sent=500
+target=450
 rate=250 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
+raw=$(sudo nping --arp -q --count $sent --rate $rate 10.100.0.30)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep Rcvd | cut -d ' ' -f 8)
+# Parse output
+received=$(printf "%s" "$raw" | grep Rcvd | cut -d ' ' -f 8)
+
+# If we receive more than 450 then the test passes
+if [ "$received" -gt "$target" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/build-and-deploy/build-and-deploy.sh
+++ b/tests/build-and-deploy/build-and-deploy.sh
@@ -8,18 +8,15 @@ instID=$($moth inspect-instance $instAlias -o id)
 naclID=$($moth push-nacl tests/build-and-deploy/interface.nacl {{.BuilderID}} -o id)
 tagBase="image"
 
-sent=0
-received=0
-
-# Build and deploy 20 times
-for i in {1..20}
+# Build and deploy 10 times
+for i in {1..10}
 do
     tag="$tagBase-$i"
     sent=$[$sent + 1]
     # Build
     imgID=$($moth build Starbase {{.BuilderID}} --instance $instID --nacl $naclID --tag $tag --waitAndPrint)
     # Deploy
-    cmdOut+=$($moth deploy $instID $imgID --wait)
+    raw+=$($moth deploy $instID $imgID --wait 2>&1)
     # Check if the instance now runs the built image and that it reports the given tag:
     cmdOutImgID=$($moth inspect-instance $instID -o json | jq -r '.imageId')
     cmdOutTag=$($moth inspect-instance $instID -o json | jq -r '.tag')
@@ -29,16 +26,25 @@ do
 done
 
 # If none of the commands above failed it means that we were successful
-rate=0.1
-avg=0
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/demo/hey-demo.sh
+++ b/tests/demo/hey-demo.sh
@@ -5,30 +5,36 @@
 # Input values to cmd
 sent=1000
 concurrency=50
-cmdOut=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30)
+raw=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30)
 
 # Parse output, important to set a default value if the command over fails
-receivedStatus=$(printf "%s" "$cmdOut" | awk '/responses/ {print $1}' )
-received=$(printf "%s" "$cmdOut" | awk '/responses/ {print $2}' )
+receivedStatus=$(printf "%s" "$raw" | awk '/responses/ {print $1}' )
+received=$(printf "%s" "$raw" | awk '/responses/ {print $2}' )
 
 if [[ "$receivedStatus" != "[200]" ]]; then
     received=0;
-elif [ -z $received ]; then
-    received=0;
+
+rate=$(printf "%s" "$raw" | awk '/Requests\/sec/ {print $2}' )
+
+if [ "$sent" -eq "$received" ]; then
+  result=true
 fi
 
-rate=$(printf "%s" "$cmdOut" | awk '/Requests\/sec/ {print $2}' )
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
 if [ -z $rate ]; then rate=0; fi
-avg=$(printf "%s" "$cmdOut" | awk '/Average/ {print $2}' )
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/dnat-snat-firewall-1/nping.sh
+++ b/tests/dnat-snat-firewall-1/nping.sh
@@ -11,20 +11,34 @@ mode="--tcp-connect"
 port="8080"
 # delay=
 
-cmdOut=$(nping -c $sent $mode -p $port --rate $rate 10.100.0.160)
+raw=$(nping -c $sent $mode -p $port --rate $rate 10.100.0.160)
 
-res=$(printf "%s" "$cmdOut" | grep "Successful connections:")
+res=$(printf "%s" "$raw" | grep "Successful connections:")
 
 # attempts=$(printf "%s" "$res" | cut -d ' ' -f 4)
 received=$(printf "%s" "$res" | cut -d ' ' -f 8)
 # successful=$(printf "%s" "$res" | cut -d ' ' -f 8)
 # failed=$(printf "%s" "$res" | cut -d ' ' -f 11)
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/dnat-snat-firewall-2/nping.sh
+++ b/tests/dnat-snat-firewall-2/nping.sh
@@ -12,20 +12,34 @@ mode="--tcp-connect"
 port="1600"
 # delay=
 
-cmdOut=$(nping -c $sent $mode -p $port --rate $rate 10.100.0.30)
+raw=$(nping -c $sent $mode -p $port --rate $rate 10.100.0.30)
 
-res=$(printf "%s" "$cmdOut" | grep "Successful connections:")
+res=$(printf "%s" "$raw" | grep "Successful connections:")
 
 # attempts=$(printf "%s" "$res" | cut -d ' ' -f 4)
 received=$(printf "%s" "$res" | cut -d ' ' -f 8)
 # successful=$(printf "%s" "$res" | cut -d ' ' -f 8)
 # failed=$(printf "%s" "$res" | cut -d ' ' -f 11)
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/dnat-snat-get-file/hey-get-file-test-with-sleep.sh
+++ b/tests/dnat-snat-get-file/hey-get-file-test-with-sleep.sh
@@ -13,25 +13,31 @@
 sent=100
 concurrency=50
 
-cmdOut=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30:1600/1GB_file.txt)
+raw=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30:1600/1GB_file.txt)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | awk '/responses/ {print $2}' )
+# Parse output
+received=$(printf "%s" "$raw" | awk '/responses/ {print $2}' )
+rate=$(printf "%s" "$raw" | awk '/Requests\/sec/ {print $2}' )
+
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-rate=$(printf "%s" "$cmdOut" | awk '/Requests\/sec/ {print $2}' )
 if [ -z $rate ]; then rate=0; fi
-avg=$(printf "%s" "$cmdOut" | awk '/Average/ {print $2}' )
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-	--arg dataReceived $received \
-	--arg dataRate $rate \
-	--arg dataAvg $avg \
-	--arg dataFull "$cmdOut" \
-	'. | .["sent"]=($dataSent|tonumber) |
-	.["received"]=($dataReceived|tonumber) |
-	.["rate"]=($dataRate|tonumber) |
-	.["avg"]=($dataAvg|tonumber) |
-	.["raw"]=$dataFull'<<<'{}'
-
-sleep 5s
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/dnat-snat/hey-http-test.sh
+++ b/tests/dnat-snat/hey-http-test.sh
@@ -18,8 +18,6 @@ rate=$(printf "%s" "$raw" | awk '/Requests\/sec/ {print $2}' )
 # Only passes if 100% of packets were received
 if [ "$sent" -eq "$received" ]; then
   result=true
-else
-  result=false
 fi
 
 if [ -z $result ]; then result=false; fi

--- a/tests/firewall-shouldfail/ping.sh
+++ b/tests/firewall-shouldfail/ping.sh
@@ -6,18 +6,27 @@ sent=20
 rate=5 # Requests pr second, higher than 5 requires sudo
 cmdOut=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.160)
 received=$(printf "%s" "$cmdOut" | grep received | cut -d ' ' -f 4)
-avg=$(printf "%s" "$cmdOut" | grep rtt | grep -oP '=.*?/\K[0-9\.]*')
-if [ -z $avg ]; then
-  avg=0
+
+# Fail test if there were received packets. This test should not succeed
+if [ "$received" -eq "0" ]; then
+  result=true
 fi
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/firewall-shouldfail/testspec.json
+++ b/tests/firewall-shouldfail/testspec.json
@@ -1,5 +1,4 @@
 {
   "clientcommandscript": "ping.sh",
-  "naclfile": "firewall-plain.nacl",
-  "shouldfail": true
+  "naclfile": "firewall-plain.nacl"
 }

--- a/tests/gateway/ping.sh
+++ b/tests/gateway/ping.sh
@@ -5,21 +5,30 @@
 # Input values to cmd
 sent=5
 rate=5 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.150)
+raw=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.150)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep received | cut -d ' ' -f 4)
+# Parse output
+received=$(printf "%s" "$raw" | grep received | cut -d ' ' -f 4)
+
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-avg=$(printf "%s" "$cmdOut" | grep rtt | grep -oP '=.*?/\K[0-9\.]*')
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/interface/ping.sh
+++ b/tests/interface/ping.sh
@@ -5,21 +5,31 @@
 # Input values to cmd
 sent=5
 rate=5 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.30)
+raw=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.30)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep received | cut -d ' ' -f 4)
+# Process output
+received=$(printf "%s" "$raw" | grep received | cut -d ' ' -f 4)
+if [ "$sent" -eq "$received" ]; then
+  result=true
+else
+  result=false
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-avg=$(printf "%s" "$cmdOut" | grep rtt | grep -oP '=.*?/\K[0-9\.]*')
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/interface/ping.sh
+++ b/tests/interface/ping.sh
@@ -11,8 +11,6 @@ raw=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.30)
 received=$(printf "%s" "$raw" | grep received | cut -d ' ' -f 4)
 if [ "$sent" -eq "$received" ]; then
   result=true
-else
-  result=false
 fi
 
 if [ -z $result ]; then result=false; fi

--- a/tests/ipdnat/ping.sh
+++ b/tests/ipdnat/ping.sh
@@ -5,21 +5,30 @@
 # Input values to cmd
 sent=5
 rate=5 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.200)
+raw=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.200)
 
-# Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep received | cut -d ' ' -f 4)
+# Parse output
+received=$(printf "%s" "$raw" | grep received | cut -d ' ' -f 4)
+
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-avg=$(printf "%s" "$cmdOut" | grep rtt | grep -oP '=.*?/\K[0-9\.]*')
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/ipsnat/ping.sh
+++ b/tests/ipsnat/ping.sh
@@ -5,21 +5,30 @@
 # Input values to cmd
 sent=5
 rate=5 # Requests pr second, higher than 5 requires sudo
-cmdOut=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.200)
+raw=$(ping -c $sent -i $(awk "BEGIN {print 1/$rate}") -q 10.100.0.200)
 
 # Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | grep received | cut -d ' ' -f 4)
-if [ -z $received ]; then received=0; fi
-avg=$(printf "%s" "$cmdOut" | grep rtt | grep -oP '=.*?/\K[0-9\.]*')
-if [ -z $avg ]; then avg=0; fi
+received=$(printf "%s" "$raw" | grep received | cut -d ' ' -f 4)
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/load-balancer-get-file/hey-get-file-via-lb-with-sleep.sh
+++ b/tests/load-balancer-get-file/hey-get-file-via-lb-with-sleep.sh
@@ -13,25 +13,31 @@
 sent=100
 concurrency=50
 
-cmdOut=$(sudo docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30:90/1GB_file.txt)
+raw=$(sudo docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30:90/1GB_file.txt)
 
 # Parse output, important to set a default value if the command over fails
-received=$(printf "%s" "$cmdOut" | awk '/responses/ {print $2}' )
+received=$(printf "%s" "$raw" | awk '/responses/ {print $2}' )
+rate=$(printf "%s" "$raw" | awk '/Requests\/sec/ {print $2}' )
+
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
 if [ -z $received ]; then received=0; fi
-rate=$(printf "%s" "$cmdOut" | awk '/Requests\/sec/ {print $2}' )
 if [ -z $rate ]; then rate=0; fi
-avg=$(printf "%s" "$cmdOut" | awk '/Average/ {print $2}' )
-if [ -z $avg ]; then avg=0; fi
-
-jq  --arg dataSent $sent \
-	--arg dataReceived $received \
-	--arg dataRate $rate \
-	--arg dataAvg $avg \
-	--arg dataFull "$cmdOut" \
-	'. | .["sent"]=($dataSent|tonumber) |
-	.["received"]=($dataReceived|tonumber) |
-	.["rate"]=($dataRate|tonumber) |
-	.["avg"]=($dataAvg|tonumber) |
-	.["raw"]=$dataFull'<<<'{}'
-
-sleep 5s
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/load-balancer/nping.sh
+++ b/tests/load-balancer/nping.sh
@@ -10,18 +10,32 @@ mode="--tcp-connect"
 port=90
 # delay=
 
-cmdOut=$(nping -c $sent $mode -p $port --rate $rate 10.100.0.30)
-res=$(printf "%s" "$cmdOut" | grep "Successful connections:")
+raw=$(nping -c $sent $mode -p $port --rate $rate 10.100.0.30)
+res=$(printf "%s" "$raw" | grep "Successful connections:")
 # attempts=$(printf "%s" "$res" | cut -d ' ' -f 4)
 received=$(printf "%s" "$res" | cut -d ' ' -f 8)
 # successful=$(printf "%s" "$res" | cut -d ' ' -f 8)
 # failed=$(printf "%s" "$res" | cut -d ' ' -f 11)
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/panics/panicCheck.sh
+++ b/tests/panics/panicCheck.sh
@@ -10,35 +10,45 @@ image_ID={{.ImageID}}
 sent=1
 received=0
 rate=1
-avg=0
 
 # Check number of panics from before
 panics_before=$($moth instance-panics $alias | shasum | cut -d " " -f 1)
 
 # Deploy image to instance
-cmdOut="Deploy: ""$($moth deploy --wait $alias $image_ID)"" "
+raw="Deploy: ""$($moth deploy --wait $alias $image_ID)"" "
 
 # Wait until the panic has been received
 for i in {1..15}; do
   sleep 1
   panics_now=$($moth instance-panics $alias | shasum | cut -d " " -f 1)
   if [ "$panics_now" != "$panics_before" ]; then
-    cmdOut+="Time taken to receive panic: $i seconds"
+    raw+="Time taken to receive panic: $i seconds"
     received=1
-    avg=$i
     break
   else
     :
   fi
 done
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/udp/udp_nping.sh
+++ b/tests/udp/udp_nping.sh
@@ -7,15 +7,14 @@ port=4242
 # delay=
 data="hi"
 
-cmdOut=$(nping -c $sent --rate $rate $mode -p $port --data-string $data 10.100.0.30)
-res=$(printf "%s" "$cmdOut" | grep "UDP packets")
+raw=$(nping -c $sent --rate $rate $mode -p $port --data-string $data 10.100.0.30)
+res=$(printf "%s" "$raw" | grep "UDP packets")
 
 # Possible:
 # attempts=$(printf "%s" "$res" | cut -d ' ' -f 4)
 # if [ -z $attempts ]; then attempts=0; fi
 
 received=$(printf "%s" "$res" | cut -d ' ' -f 7)
-if [ -z $received ]; then received=0; fi
 # Or:
 # successful=$(printf "%s" "$res" | cut -d ' ' -f 7)
 # if [ -z $successful ]; then successful=0; fi
@@ -24,11 +23,25 @@ if [ -z $received ]; then received=0; fi
 # failed=$(printf "%s" "$res" | cut -d ' ' -f 10)
 # if [ -z $failed ]; then failed=0; fi
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
+
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'

--- a/tests/upgrade/upgrade.sh
+++ b/tests/upgrade/upgrade.sh
@@ -58,17 +58,25 @@ cmdOut+=$($moth upgrade $instID --service Starbase --waitAndPrintImageID)
 received=$[$received + 1]
 
 
-# If none of the commands above failed it means that we were successful
-rate=0.1
-avg=0
+if [ "$sent" -eq "$received" ]; then
+  result=true
+fi
 
-jq  --arg dataSent $sent \
-    --arg dataReceived $received \
-    --arg dataRate $rate \
-    --arg dataAvg $avg \
-    --arg dataFull "$cmdOut" \
-    '. | .["sent"]=($dataSent|tonumber) |
-    .["received"]=($dataReceived|tonumber) |
-    .["rate"]=($dataRate|tonumber) |
-    .["avg"]=($dataAvg|tonumber) |
-    .["raw"]=$dataFull'<<<'{}'
+if [ -z $result ]; then result=false; fi
+if [ -z $sent ]; then sent=0; fi
+if [ -z $received ]; then received=0; fi
+if [ -z $rate ]; then rate=0; fi
+if [ -z $raw ]; then raw=""; fi
+jq \
+  --argjson result $result \
+  --argjson sent $sent \
+  --argjson received $received \
+  --argjson rate $rate \
+  --arg raw "$raw" \
+  '. |
+  .["result"]=$result |
+  .["sent"]=$sent |
+  .["received"]=$received |
+  .["rate"]=$rate |
+  .["raw"]=$raw
+  '<<<'{}'


### PR DESCRIPTION
All tests are now responsible for setting the test result: `true/false` to indicate if the test passed or not. This made it so that the `shouldfail` testspec option could be removed. 

Test output now looks like:
```
========================== test: firewall-shouldfail ==========================
+----------------+-------------------------------------------------+
| Path           | tests/firewall-shouldfail/ping.sh               |
| Script type    | [X] ClientCommandScript / [ ] HostCommandScript |
| Custom service |                                                 |
| No deploy      | [ ]                                             |
| Skip rebuild   | [X]                                             |
+----------------+-------------------------------------------------+
INFO[0026] Preparing clients
INFO[0026] Starting test
+----------------+-------------------------------------------------+
| Result         | [ PASS ]                                        |
| Sent           | 20                                              |
| Received       | 0                                               |
| Percentage     | 0.0%                                            |
| Rate           | 5.00                                            |
| Duration       | 16s                                             |
+----------------+-------------------------------------------------+
INFO[0043] Status: connected, IOSVersion: v0.13.0,
================================================================================
```